### PR TITLE
Only ask for rustc's version, not its full triple

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 extern crate version_check;
 
 fn main() {
-    let (version, _channel, _date) = version_check::triple().expect("Rustc to give us its version");
+    let version = version_check::Version::read().expect("Rustc to give us its version");
 
     for i in 0..65536 {
         if version.at_least(&format!("1.{}.0", i)) {


### PR DESCRIPTION
Fedora's rustc does not report a release channel or date, only a version.
Asking version_check for the full triple therefore fails, breaking the build.

We only need the version, so only ask version_check for that.